### PR TITLE
Allow alias and arguments for field settings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,21 @@
+{
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "overrides": [
+    {
+      "files": "package*.json",
+      "options": {
+        "printWidth": 1000
+      }
+    },
+    {
+      "files": "*.yml",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+- allow field [alias](https://graphql.org/learn/queries/#aliases) and [arguments](https://graphql.org/learn/queries/#arguments)
+  in query settings
+
 ## v0.5.4
 
 - allow to build more complex update mutations

--- a/src/__tests__/field.test.ts
+++ b/src/__tests__/field.test.ts
@@ -1,102 +1,83 @@
 import merge from 'lodash/merge'
-import {
-  createQueryFromType,
-  SimpleFieldHandlers,
-} from '../field'
+import { createQueryFromType, SimpleFieldHandlers } from '../field'
 import { ContentType, ContentBlockType } from './helpers'
 
 describe('createQueryFromType', () => {
-
   it('provides simple field types', () => {
     expect(
-      createQueryFromType(
-        {
-          typeName: 'Content',
-          typeMap: {
-            Content: ContentType,
-            ContentBlock: ContentBlockType,
+      createQueryFromType({
+        typeName: 'Content',
+        typeMap: {
+          Content: ContentType,
+          ContentBlock: ContentBlockType
+        },
+        handlers: SimpleFieldHandlers,
+        settings: {
+          nodeId: true,
+          name: true,
+          blocks: true,
+          block: {
+            type: true
           },
-          handlers: SimpleFieldHandlers,
-          settings: {
-            nodeId: true,
-            name: true,
-            blocks: true,
-            block: {
-              type: true
-            },
-            '=de': {
-              arguments: 'filter: {lang: {equalTo: DE}}',
-              query: {
-                blocks: {
-                  type: true,
-                }
+          '=de': {
+            arguments: 'filter: {lang: {equalTo: DE}}',
+            query: {
+              blocks: {
+                type: true
               }
-            },
-            pubTs: true,
-            deleted: true,
-            id: true,
-            ts: true,
-            author: true,
-          }
+            }
+          },
+          pubTs: true,
+          deleted: true,
+          id: true,
+          ts: true,
+          author: true
         }
-      ),
+      })
     ).toStrictEqual(
-      ' de: blocks(filter: {lang: {equalTo: DE}}) {  type } author block {  type } blocks deleted id name nodeId pubTs ts',
+      ' de: blocks(filter: {lang: {equalTo: DE}}) {  type } author block {  type } blocks deleted id name nodeId pubTs ts'
     )
   })
 
   it('allows to define alias w/o arguments', () => {
     expect(
-      createQueryFromType(
-        {
-          typeName: 'Content',
-          typeMap: {
-            Content: ContentType,
-            ContentBlock: ContentBlockType,
-          },
-          handlers: SimpleFieldHandlers,
-          settings: {
-            '=effective': {
-              query: {
-                pubTs: true,
+      createQueryFromType({
+        typeName: 'Content',
+        typeMap: {
+          Content: ContentType,
+          ContentBlock: ContentBlockType
+        },
+        handlers: SimpleFieldHandlers,
+        settings: {
+          '=effective': {
+            query: {
+              pubTs: true
             }
           }
         }
-      ),
-    ).toStrictEqual(
-      ' effective: pubTs',
-    )
+      })
+    ).toStrictEqual(' effective: pubTs')
   })
 
   it('can be configured for object fields', () => {
-    const myFieldHandlers = merge(
-      {},
-      SimpleFieldHandlers,
-      {
-        nodeId: () => {
-          return 'changedNameForNodeId'
-        }
+    const myFieldHandlers = merge({}, SimpleFieldHandlers, {
+      nodeId: () => {
+        return 'changedNameForNodeId'
       }
-    )
+    })
     expect(
-      createQueryFromType(
-        {
-          typeName: 'Content',
-          typeMap: {
-            Content: ContentType,
-          },
-          handlers: myFieldHandlers,
-          settings: {
-            nodeId: true,
-            name: true,
-            id: true,
-          },
+      createQueryFromType({
+        typeName: 'Content',
+        typeMap: {
+          Content: ContentType
+        },
+        handlers: myFieldHandlers,
+        settings: {
+          nodeId: true,
+          name: true,
+          id: true
         }
-      ),
-    ).toStrictEqual(
-      ' id name changedNameForNodeId',
-    )
+      })
+    ).toStrictEqual(' id name changedNameForNodeId')
   })
-  })
-
 })

--- a/src/__tests__/field.test.ts
+++ b/src/__tests__/field.test.ts
@@ -16,7 +16,7 @@ describe('createQueryFromType', () => {
             Content: ContentType,
             ContentBlock: ContentBlockType,
           },
-          handlers: SimpleFieldHandlers
+          handlers: SimpleFieldHandlers,
           settings: {
             nodeId: true,
             name: true,
@@ -24,6 +24,14 @@ describe('createQueryFromType', () => {
             block: {
               type: true
             }
+            '=de': {
+              parameters: 'filter: {lang: {equalTo: DE}}',
+              query: {
+                blocks: {
+                  type: true,
+                }
+              }
+            },
             pubTs: true,
             deleted: true,
             id: true,
@@ -33,7 +41,30 @@ describe('createQueryFromType', () => {
         }
       ),
     ).toStrictEqual(
-      ' nodeId name blocks block {  type } pubTs deleted id ts author',
+      ' de: blocks(filter: {lang: {equalTo: DE}}) {  type } author block {  type } blocks deleted id name nodeId pubTs ts',
+    )
+  })
+
+  it('allows to define alias w/o parameters', () => {
+    expect(
+      createQueryFromType(
+        {
+          typeName: 'Content',
+          typeMap: {
+            Content: ContentType,
+            ContentBlock: ContentBlockType,
+          },
+          handlers: SimpleFieldHandlers,
+          settings: {
+            '=effective': {
+              query: {
+                pubTs: true,
+            }
+          }
+        }
+      ),
+    ).toStrictEqual(
+      ' effective: pubTs',
     )
   })
 
@@ -54,16 +85,16 @@ describe('createQueryFromType', () => {
           typeMap: {
             Content: ContentType,
           },
-          handlers: myFieldHandlers
+          handlers: myFieldHandlers,
           settings: {
             nodeId: true,
             name: true,
             id: true,
-          }
+          },
         }
       ),
     ).toStrictEqual(
-      ' changedNameForNodeId name id',
+      ' id name changedNameForNodeId',
     )
   })
   })

--- a/src/__tests__/field.test.ts
+++ b/src/__tests__/field.test.ts
@@ -3,7 +3,7 @@ import {
   createQueryFromType,
   SimpleFieldHandlers,
 } from '../field'
-import { ContentPatch, ContentType, ContentBlockType } from './helpers'
+import { ContentType, ContentBlockType } from './helpers'
 
 describe('createQueryFromType', () => {
 

--- a/src/__tests__/field.test.ts
+++ b/src/__tests__/field.test.ts
@@ -23,9 +23,9 @@ describe('createQueryFromType', () => {
             blocks: true,
             block: {
               type: true
-            }
+            },
             '=de': {
-              parameters: 'filter: {lang: {equalTo: DE}}',
+              arguments: 'filter: {lang: {equalTo: DE}}',
               query: {
                 blocks: {
                   type: true,
@@ -45,7 +45,7 @@ describe('createQueryFromType', () => {
     )
   })
 
-  it('allows to define alias w/o parameters', () => {
+  it('allows to define alias w/o arguments', () => {
     expect(
       createQueryFromType(
         {

--- a/src/__tests__/resource.test.ts
+++ b/src/__tests__/resource.test.ts
@@ -69,9 +69,9 @@ describe('resource', () => {
       expect(result.variables).toStrictEqual({ id: 1 })
       expect(print(result.query)).toStrictEqual(`query test($id: Int!) {
   test(id: $id) {
-    nodeId
-    name
     id
+    name
+    nodeId
   }
 }
 `)
@@ -97,9 +97,9 @@ describe('resource', () => {
       expect(print(result.query)).toStrictEqual(`query tests($ids: [Int!]) {
   tests(filter: {id: {in: $ids}}) {
     nodes {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
   }
 }
@@ -150,9 +150,9 @@ describe('resource', () => {
         .toStrictEqual(`mutation WithParameters($input: CreateTestInput!) {
   createTest(input: $input) {
     test {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
   }
 }
@@ -196,9 +196,9 @@ describe('resource', () => {
         .toStrictEqual(`mutation WithParameters($input: UpdateTestInput!) {
   updateTest(input: $input) {
     test {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
   }
 }
@@ -289,9 +289,9 @@ describe('resource', () => {
         .toStrictEqual(`query tests($offset: Int!, $first: Int!, $filter: TestFilter, $orderBy: [TestsOrderBy!]) {
   tests(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
     nodes {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
     totalCount
   }
@@ -374,9 +374,9 @@ describe('resource', () => {
         .toStrictEqual(`query tests($offset: Int!, $first: Int!, $filter: TestFilter, $orderBy: [TestsOrderBy!]) {
   tests(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
     nodes {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
     totalCount
   }
@@ -427,9 +427,9 @@ describe('resource', () => {
         .toStrictEqual(`mutation WithParameters($input: DeleteTestInput!) {
   deleteTest(input: $input) {
     test {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
   }
 }
@@ -471,9 +471,9 @@ describe('resource', () => {
       expect(print(result.query))
         .toStrictEqual(`query compoundByNodeId($id: ID!) {
   compoundByNodeId(nodeId: $id) {
-    nodeId
-    name
     id
+    name
+    nodeId
   }
 }
 `)
@@ -502,9 +502,9 @@ describe('resource', () => {
       expect(print(result.query)).toStrictEqual(`query compounds($ids: [ID!]) {
   compounds(filter: {nodeId: {in: $ids}}) {
     nodes {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
   }
 }
@@ -562,9 +562,9 @@ describe('resource', () => {
         .toStrictEqual(`mutation WithParameters($input: CreateCompoundInput!) {
   createCompound(input: $input) {
     compound {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
   }
 }
@@ -614,9 +614,9 @@ describe('resource', () => {
         .toStrictEqual(`mutation WithParameters($input: UpdateCompoundByNodeIdInput!) {
   updateCompoundByNodeId(input: $input) {
     compound {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
   }
 }
@@ -708,9 +708,9 @@ describe('resource', () => {
         .toStrictEqual(`query compounds($offset: Int!, $first: Int!, $filter: CompoundFilter, $orderBy: [CompoundsOrderBy!]) {
   compounds(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
     nodes {
-      nodeId
-      name
       id
+      name
+      nodeId
     }
     totalCount
   }

--- a/src/field.ts
+++ b/src/field.ts
@@ -21,7 +21,7 @@ import { isObjectOrListOfObjectsType, fieldType } from './gqltype'
  */
 export const ObjectField = (
   field: GQLType,
-  parameters: string | undefined,
+  fieldArguments: string | undefined,
   params: QueryFromTypeParams
 ) => {
   const { typeMap } = params
@@ -29,8 +29,8 @@ export const ObjectField = (
   if (!nodeType) {
     return ''
   }
-  const paramString = (parameters && `(${parameters})`) || ''
-  return `${field.name}${paramString} { ${createQueryFromType({
+  const argString = (fieldArguments && `(${fieldArguments})`) || ''
+  return `${field.name}${argString} { ${createQueryFromType({
     ...params,
     typeName: nodeType.name
   })} }`
@@ -44,7 +44,7 @@ export const ObjectField = (
  */
 export const SimpleFieldHandler = (
   field: GQLType,
-  parameters: string | undefined,
+  fieldArguments: string | undefined,
   params: QueryFromTypeParams
 ): string => {
   const { settings } = params
@@ -56,7 +56,7 @@ export const SimpleFieldHandler = (
     // render as a simple field
     return `${field.name}`
   }
-  return ObjectField(field, parameters, params)
+  return ObjectField(field, fieldArguments, params)
 }
 
 
@@ -88,11 +88,11 @@ export const createQueryFromType = (params: QueryFromTypeParams): string => {
     )
 
     let aliasName: string = ''
-    let parameters: string | undefined
+    let fieldArguments: string | undefined
     if (fieldName.startsWith('=')) {
-      // fields starting with = are treated as alias fields for query with possible parameters
+      // fields starting with = are treated as alias fields for query with possible arguments
       aliasName = fieldName.substr(1)
-      parameters = get(setting, 'parameters')
+      fieldArguments = get(setting, 'arguments')
       const query = get(setting, 'query')
       fieldName = Object.keys(query || {})[0]
       setting = query[fieldName]
@@ -105,7 +105,7 @@ export const createQueryFromType = (params: QueryFromTypeParams): string => {
         defaultHandler
       )
       if (handler) {
-        const fieldQuery = handler(typeFieldsMap[fieldName], parameters, {
+        const fieldQuery = handler(typeFieldsMap[fieldName], fieldArguments, {
           ...params,
           settings: setting
         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,12 @@ export type GQLTypeMap = {
   [key: string]: GQLType
 }
 
+export type GQLFieldSettings = {
+  arguments?: string
+}
+
 export type GQLQueryProperties = {
-  [propertyName: string]: boolean | GQLQueryProperties
+  [propertyName: string]: boolean | GQLQueryProperties | GQLFieldSettings
 }
 
 export type GQLQuerySettings = {
@@ -64,7 +68,7 @@ export type IntrospectedTypes = {
 
 /**
  * Resources
- * 
+ *
  * Resources can be configured via the resource options in the definition of
  * react admin.
  */
@@ -140,7 +144,7 @@ export type QueryFromTypeParams = {
   settings?: GQLQueryProperties | boolean
 }
 
-export type FieldHandler = 
+export type FieldHandler =
   (field: GQLType, params: QueryFromTypeParams) => string
 
 export interface FieldHandlers {


### PR DESCRIPTION
this allows to rename fields by using settings and to optionally add [arguments](https://graphql.org/learn/queries/#arguments)

example 
```
"=myAliasName": {
  arguments="condition: { lang: DE}, orderBy: pubTS",
  query: {
    myRealListFieldName: {
      title
    }
  }
}
```