### PR TITLE
Fix update for compound key resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix update for compound key resources
+
 - allow field [alias](https://graphql.org/learn/queries/#aliases) and [arguments](https://graphql.org/learn/queries/#arguments)
   in query settings
 

--- a/src/__tests__/resource.test.ts
+++ b/src/__tests__/resource.test.ts
@@ -603,7 +603,7 @@ describe('resource', () => {
       })
       expect(result.variables).toStrictEqual({
         input: {
-          id: 'nodeId:1',
+          nodeId: 'nodeId:1',
           patch: {
             id: 1,
             name: 'the name',

--- a/src/field.ts
+++ b/src/field.ts
@@ -1,14 +1,12 @@
-import { get, reduce, sortBy } from 'lodash'
-import { fieldIsObjectOrListOfObject } from './utils'
+import { get } from 'lodash'
 import {
   GQLType,
-  GQLTypeMap,
   GQLQueryProperties,
   FieldHandler,
   FieldHandlers,
   QueryFromTypeParams
 } from './types'
-import { isObjectOrListOfObjectsType, fieldType } from './gqltype'
+import { fieldType } from './gqltype'
 
 /**
  * The ObjectField can be used for list of objects and for pure object fields.

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -193,7 +193,7 @@ export class BaseResource implements IResource {
         `Query "${this.queryTypeName}" for type "${this.typeName}" not found in introspection`,
       )
     }
-    
+
     // Getting the primary keys:
     //   The arguments for the query to get the resource (defined as lowercased
     //   resource name) are the fields defining the primary key of the resource.
@@ -208,7 +208,7 @@ export class BaseResource implements IResource {
     this.primaryKeyTypeName = this.hasCompoundKey
       ? 'ID'
       : primaryKeys[0].type.name || primaryKeys[0].type.ofType.name
-    
+
     this.prepareForReactAdmin = this.hasCompoundKey
       ? (data: any): any => {
           return {
@@ -350,6 +350,7 @@ export class BaseResource implements IResource {
       inputName = inputName + resultName
       resultName = resultName + ':'
     }
+    const inputId = this.hasCompoundKey ? 'nodeId' : this.primaryKeyFieldName
     return {
       query: `${resultName} ${this.updateResourceName}(input: $${inputName}) {
         ${this.queryTypeName} {
@@ -360,7 +361,7 @@ export class BaseResource implements IResource {
       },
       variables: {
         [`${inputName}`]: {
-          id: this.idConverter(params.id),
+          [inputId]: this.idConverter(params.id),
           patch: this.recordToVariables(
             preparedData,
             this.introspection.patchType,
@@ -461,7 +462,7 @@ export class BaseResource implements IResource {
       settings: this.querySettings[forQuery],
     })
   }
- 
+
   createGetListQuery() {
     return `${this.pluralizedQueryTypeName} (
       $offset: Int!,


### PR DESCRIPTION
resources with a compound key use `updateXYByNodeId` instead of `updateXY` mutation

and `updateXYByNodeId` requires `nodeId` as input param instead of `id`:

```gql
updatePoiDetailByNodeId(input: {patch: {title: "new title3"}, nodeId:"WyJwb2lfZGV0YWlscyIsMTAsImRlIl0="}) {
    poiDetail {
      poi {
        detailsList {
          title
          lang
        }
      }
    }
  }
```