### PR TITLE
remove __typename as this breaks simple object fields such as point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Feature
 
+- Omit `__typename` property on object fields in input/update mutations
 - Support the use of arguments on simple fields.
 - Possibility to use an alternative backendResourceName in resource options
 

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -777,6 +777,18 @@ export const TestTypes = [
         defaultValue: null,
         __typename: '__InputValue',
         description: null,
+        name: 'block',
+        type: {
+          __typename: '__Type',
+          kind: 'OBJECT',
+          name: 'ContentBlock',
+          ofType: null,
+        },
+      },
+      {
+        defaultValue: null,
+        __typename: '__InputValue',
+        description: null,
         name: 'pubTs',
         type: {
           __typename: '__Type',

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,4 +1,6 @@
 import get from 'lodash/get'
+import isPlainObject from 'lodash/isPlainObject'
+import omit from 'lodash/omit'
 import gql from 'graphql-tag'
 import {
   GET_LIST,
@@ -620,9 +622,14 @@ export class BaseResource implements IResource {
           }
         }
       }
+      let data = input[inputName]
+      if (isPlainObject(data)) {
+        // strip unneeded metadata from ObjectFields
+        data = omit(data, ['__typename'])
+      }
       return {
         ...current,
-        [inputName]: input[inputName],
+        [inputName]: data,
       }
     }, {})
   }


### PR DESCRIPTION
if __typename property is present in the mutation we'd get the following error:

```
GraphQL error: Variable "$input" got invalid value { x: 49.405079, y:
9.74352, __typename: "Point" } at "input.patch.coords"; Field
"__typename" is not defined by type PointInput.
```

decided to use this shortcut instead of filtering out all fields not present in the `INPUT_OBJECT` of the
introspection result for every ObjectField.