### PR TITLE
Support filter for 'SCALAR' type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Development
 
+- Support filter for 'SCALAR' type (provided by postgraphile-plugin-fulltext-filter)
 - Use Typescript 4.0.3
 - Adapted a lot of dependecies to align with lovely-ra
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Development
 
-- Support filter for 'SCALAR' type (provided by postgraphile-plugin-fulltext-filter)
+- Support filter for scalar type `FullText` (provided by postgraphile-plugin-fulltext-filter)
 - Use Typescript 4.0.3
 - Adapted a lot of dependecies to align with lovely-ra
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
     "lodash": "^4.17.20",
+    "pg-tsquery": "^8.1.0",
     "react-admin": "^3.9.2",
     "ra-data-graphql": "^3.9.2"
   },

--- a/src/__tests__/filters.test.ts
+++ b/src/__tests__/filters.test.ts
@@ -26,6 +26,11 @@ const ENUMType: GQLType = {
   name: 'ContractType',
 }
 
+const SCALARType: GQLType = {
+  kind: 'SCALAR',
+  name: 'Fulltext',
+}
+
 const UnknownType: GQLType = {
   kind: 'Kind',
   name: 'Unknown',
@@ -240,6 +245,14 @@ describe('filters', () => {
         expect(
           mapFilterType(IntListType, [2, 3], ['notDistinctFrom']),
         ).toStrictEqual({ notDistinctFrom: [2, 3] })
+      })
+    })
+
+    describe('type SCALAR operation', () => {
+      it('default', () => {
+        expect(mapFilterType(SCALARType, 'V', [])).toStrictEqual({
+          matches: 'V*',
+        })
       })
     })
 

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -57,6 +57,20 @@ export const ContentType = {
       deprecationReason: null,
     },
     {
+      name: 'myFulltext',
+      description: null,
+      args: [],
+      type: {
+        kind: 'SCALAR',
+        name: 'FullText',
+        ofType: null,
+        __typename: '__Type',
+      },
+      isDeprecated: false,
+      deprecationReason: null,
+      __typename: '__Field',
+    },
+    {
       name: 'blocks',
       type: {
         __typename: '__Type',
@@ -346,6 +360,18 @@ export const ContentPatch = {
       },
     },
     {
+      name: 'myFulltext',
+      description: null,
+      type: {
+        kind: 'SCALAR',
+        name: 'FullText',
+        ofType: null,
+        __typename: '__Type',
+      },
+      defaultValue: null,
+      __typename: '__InputValue',
+    },
+    {
       defaultValue: null,
       __typename: '__InputValue',
       description: null,
@@ -569,6 +595,20 @@ export const TestTypes: Array<GQLType> = [
         deprecationReason: null,
       },
       {
+        name: 'myFulltext',
+        description: null,
+        args: [],
+        type: {
+          kind: 'SCALAR',
+          name: 'FullText',
+          ofType: null,
+          __typename: '__Type',
+        },
+        isDeprecated: false,
+        deprecationReason: null,
+        __typename: '__Field',
+      },
+      {
         name: 'blocks',
         type: {
           __typename: '__Type',
@@ -757,6 +797,18 @@ export const TestTypes: Array<GQLType> = [
           name: 'Boolean',
           ofType: null,
         },
+      },
+      {
+        name: 'myFulltext',
+        description: null,
+        type: {
+          kind: 'SCALAR',
+          name: 'FullText',
+          ofType: null,
+          __typename: '__Type',
+        },
+        defaultValue: null,
+        __typename: '__InputValue',
       },
       {
         defaultValue: null,

--- a/src/__tests__/resource.test.ts
+++ b/src/__tests__/resource.test.ts
@@ -26,6 +26,7 @@ describe('resource', () => {
     nodeId: true,
     name: true,
     id: true,
+    myFulltext: true,
   }
 
   const CompoundProperties = {
@@ -73,6 +74,7 @@ describe('resource', () => {
       expect(print(result.query)).toStrictEqual(`query test($id: Int!) {
   test(id: $id) {
     id
+    myFulltext
     name
     nodeId
   }
@@ -103,6 +105,7 @@ describe('resource', () => {
   tests(filter: {id: {in: $ids}}) {
     nodes {
       id
+      myFulltext
       name
       nodeId
     }
@@ -158,6 +161,7 @@ describe('resource', () => {
   createTest(input: $input) {
     test {
       id
+      myFulltext
       name
       nodeId
     }
@@ -206,6 +210,7 @@ describe('resource', () => {
   updateTest(input: $input) {
     test {
       id
+      myFulltext
       name
       nodeId
     }
@@ -303,6 +308,7 @@ describe('resource', () => {
   tests(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
     nodes {
       id
+      myFulltext
       name
       nodeId
     }
@@ -363,6 +369,23 @@ describe('resource', () => {
       })
     })
 
+    it('Filter specific order by commands are prepended to the sorting on GET_LIST', () => {
+      const provider = resourceFactory(introspectionResult, {
+        options: OPTIONS,
+      })
+      const result = provider(GET_LIST, 'Test', {
+        sort: { field: 'name', order: 'DESC' },
+        filter: { myFulltext: 'hello' },
+        pagination: { page: 1, perPage: 10 },
+      })
+      expect(result.variables).toStrictEqual({
+        filter: { and: [{ myFulltext: { matches: 'hello*' } }] },
+        first: 10,
+        offset: 0,
+        orderBy: ['MY_FULLTEXT_RANK_DESC', 'NAME_DESC'],
+      })
+    })
+
     it('GET_MANY_REFERENCE provides a query', () => {
       const provider = resourceFactory(introspectionResult, {
         options: OPTIONS,
@@ -392,6 +415,7 @@ describe('resource', () => {
   tests(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
     nodes {
       id
+      myFulltext
       name
       nodeId
     }
@@ -447,6 +471,7 @@ describe('resource', () => {
   deleteTest(input: $input) {
     test {
       id
+      myFulltext
       name
       nodeId
     }

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -3,7 +3,7 @@ import { GQLType, FilterFields, TypeFilterMapping } from './types'
 /**
  * Map query filter operations to backend filter names
  *
- * By using a type an an operation this mapping allows to build the filter
+ * By using a type and an operation this mapping allows to build the filter
  * parameters for postgraphile.
  */
 export const TYPE_TO_FILTER_MAPPINGS = {
@@ -80,6 +80,10 @@ export const TYPE_TO_FILTER_MAPPINGS = {
     '>': ['greaterThan', (value: Date) => value.toISOString()],
     '>=': ['greaterThanOrEqualTo', (value: Date) => value.toISOString()],
     default: ['equalTo', (value: Date) => value.toISOString()],
+  },
+  // provided by postgraphile-plugin-fulltext-filter
+  SCALAR: {
+    default: ['matches', (value: string) => `${value}*`],
   },
 } as TypeFilterMapping
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -494,7 +494,7 @@ export class BaseResource implements IResource {
     const orderBy = sort
       ? [createSortingKey(sort.field, sort.order)]
       : [NATURAL_SORTING]
-    const filters = createFilter(
+    const { filters, filterOrderBy } = createFilter(
       filter,
       this.introspection.type,
       this.typeToFilterMap,
@@ -503,7 +503,7 @@ export class BaseResource implements IResource {
       offset: (pagination.page - 1) * pagination.perPage,
       first: pagination.perPage,
       filter: filters,
-      orderBy,
+      orderBy: filterOrderBy.concat(orderBy),
     }
   }
 


### PR DESCRIPTION
This filter is provided by the `postgraphile-plugin-fulltext-filter` plugin. Appending the * to the search value also finds words that start with the given query string (`hel` -> `hello`, `help`, ...)